### PR TITLE
Add missing properties & smart current screen ID

### DIFF
--- a/src/ApiClient.php
+++ b/src/ApiClient.php
@@ -8,6 +8,7 @@ use Renderforest\Font\Collection\FontCollection;
 use Renderforest\Project\Collection\ProjectCollection;
 use Renderforest\Project\Project;
 use Renderforest\ProjectData\ProjectData;
+use Renderforest\ProjectData\Screen\Entity\Screen;
 use Renderforest\Sound\Collection\SoundCollection;
 use Renderforest\Support\SupportTicket;
 use Renderforest\Support\SupportTicketResponse;
@@ -124,12 +125,29 @@ class ApiClient
         $this->httpClient = new Client();
     }
 
+    /**
+     * @param int $projectId
+     * @param ProjectData $projectData
+     * @return int
+     * @throws GuzzleException
+     */
     public function updateProjectData(
         int $projectId,
         ProjectData $projectData
     ) {
         $endpoint = self::PROJECT_DATA_API_PATH;
         $uri = self::API_ENDPOINT . self::PROJECT_DATA_API_PATH . '/' . $projectId;
+
+        $screenIds = [];
+        /** @var Screen[] $screens */
+        $screens = $projectData->getScreens();
+        foreach ($screens as $screen) {
+            $screenIds[] = $screen->getId();
+        }
+
+        if (false === in_array($projectData->getCurrentScreenId(), $screenIds)) {
+            $projectData->setCurrentScreenId($screenIds[0]);
+        }
 
         $options = [
             'method' => 'PATCH',
@@ -1264,7 +1282,7 @@ class ApiClient
 
     /**
      * @param ProjectData $projectData
-     * @return str
+     * @return string
      * @throws GuzzleException
      */
     public function getScreenSnapshot(ProjectData $projectData): string {

--- a/src/ProjectData/ProjectData.php
+++ b/src/ProjectData/ProjectData.php
@@ -21,6 +21,7 @@ class ProjectData extends ApiEntityBase
     const KEY_TEMPLATE_ID = 'templateId';
     const KEY_CURRENT_SCREEN_ID = 'currentScreenId';
     const KEY_DURATION = 'duration';
+    const KEY_EDITING_MODE = 'editingMode';
     const KEY_FPS = 'fps';
     const KEY_EQUALIZER = 'equalizer';
     const KEY_EXTENDABLE_SCREENS = 'extendableScreens';
@@ -40,6 +41,7 @@ class ProjectData extends ApiEntityBase
 
     const WRITABLE_KEYS = [
         self::KEY_CURRENT_SCREEN_ID,
+        self::KEY_EDITING_MODE,
         self::KEY_MUTE_MUSIC,
         self::KEY_SOUNDS,
         self::KEY_PROJECT_COLORS,
@@ -47,6 +49,13 @@ class ProjectData extends ApiEntityBase
         self::KEY_STYLES,
         self::KEY_VOICE_OVER,
         self::KEY_FONTS,
+    ];
+
+    const EDITING_MODE_SIMPLE = 'simple';
+    const EDITING_MODE_ADVANCED = 'advanced';
+    const EDITING_MODES = [
+        self::EDITING_MODE_SIMPLE,
+        self::EDITING_MODE_ADVANCED,
     ];
 
     /** @var int */
@@ -57,6 +66,9 @@ class ProjectData extends ApiEntityBase
 
     /** @var int */
     protected $duration;
+
+    /** @var string */
+    protected $editingMode;
 
     /** @var int */
     protected $fps;
@@ -166,6 +178,25 @@ class ProjectData extends ApiEntityBase
     private function setDuration(int $duration): ProjectData
     {
         $this->duration = $duration;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getEditingMode(): string
+    {
+        return $this->editingMode;
+    }
+
+    /**
+     * @param string $editingMode
+     * @return ProjectData
+     */
+    public function setEditingMode(string $editingMode): ProjectData
+    {
+        $this->editingMode = $editingMode;
 
         return $this;
     }
@@ -554,6 +585,10 @@ class ProjectData extends ApiEntityBase
             $this->setCurrentScreenId($projectDataArrayData[self::KEY_CURRENT_SCREEN_ID]);
         }
 
+        if (array_key_exists(self::KEY_EDITING_MODE, $projectDataArrayData)) {
+            $this->setEditingMode($projectDataArrayData[self::KEY_EDITING_MODE]);
+        }
+
         $duration = $projectDataArrayData[self::KEY_DURATION];
         $this->setDuration($duration);
 
@@ -683,6 +718,7 @@ class ProjectData extends ApiEntityBase
             self::KEY_TEMPLATE_ID => $this->getTemplateId(),
             self::KEY_CURRENT_SCREEN_ID => $this->getCurrentScreenId(),
             self::KEY_DURATION => $this->getDuration(),
+            self::KEY_EDITING_MODE => $this->getEditingMode(),
             self::KEY_FPS => $this->getFps(),
             self::KEY_EQUALIZER => $this->isEqualizer(),
             self::KEY_EXTENDABLE_SCREENS => $this->isExtendableScreens(),

--- a/src/ProjectData/Screen/Area/Entity/AbstractArea.php
+++ b/src/ProjectData/Screen/Area/Entity/AbstractArea.php
@@ -25,6 +25,8 @@ abstract class AbstractArea extends EntityBase
     const KEY_CORDS = 'cords';
     const KEY_HEIGHT = 'height';
     const KEY_WIDTH = 'width';
+    const KEY_ORIGINAL_HEIGHT = 'originalHeight';
+    const KEY_ORIGINAL_WIDTH = 'originalWidth';
     const KEY_ORDER = 'order';
     const KEY_WORD_COUNT = 'wordCount';
     const KEY_TITLE = 'title';

--- a/src/ProjectData/Screen/Area/Entity/ImageArea.php
+++ b/src/ProjectData/Screen/Area/Entity/ImageArea.php
@@ -11,8 +11,6 @@ use Renderforest\ProjectData\Screen\Area\ImageCropParams\Entity\ImageCropParams;
 class ImageArea extends AbstractArea
 {
     const KEY_COLOR_FILTERS = 'colorFilters';
-    const KEY_ORIGINAL_HEIGHT = 'originalHeight';
-    const KEY_ORIGINAL_WIDTH = 'originalWidth';
     const KEY_MIME_TYPE = 'mimeType';
     const KEY_FILE_NAME = 'fileName';
     const KEY_WEBP_PATH = 'webpPath';

--- a/src/ProjectData/Screen/Area/Entity/TextArea.php
+++ b/src/ProjectData/Screen/Area/Entity/TextArea.php
@@ -16,6 +16,8 @@ class TextArea extends AbstractArea
         self::KEY_CORDS,
         self::KEY_HEIGHT,
         self::KEY_WIDTH,
+        self::KEY_ORIGINAL_HEIGHT,
+        self::KEY_ORIGINAL_WIDTH,
         self::KEY_ORDER,
         self::KEY_WORD_COUNT,
         self::KEY_TITLE,
@@ -24,6 +26,12 @@ class TextArea extends AbstractArea
 
     /** @var string */
     protected $type = self::AREA_TYPE_TEXT;
+
+    /** @var int */
+    protected $originalHeight;
+
+    /** @var int */
+    protected $originalWidth;
 
     /** @var bool|null */
     protected $removed;
@@ -103,6 +111,44 @@ class TextArea extends AbstractArea
     }
 
     /**
+     * @return int
+     */
+    public function getOriginalHeight(): int
+    {
+        return $this->originalHeight;
+    }
+
+    /**
+     * @param int $originalHeight
+     * @return TextArea
+     */
+    public function setOriginalHeight(int $originalHeight): TextArea
+    {
+        $this->originalHeight = $originalHeight;
+
+        return $this;
+    }
+
+    /**
+     * @return int
+     */
+    public function getOriginalWidth(): int
+    {
+        return $this->originalWidth;
+    }
+
+    /**
+     * @param int $originalWidth
+     * @return TextArea
+     */
+    public function setOriginalWidth(int $originalWidth): TextArea
+    {
+        $this->originalWidth = $originalWidth;
+
+        return $this;
+    }
+
+    /**
      * @param array $textAreaArrayData
      * @throws \Exception
      */
@@ -113,6 +159,12 @@ class TextArea extends AbstractArea
                 throw new \Exception('Missing `' . $requiredKey . '` in text area array data');
             }
         }
+
+        $originalHeight = $textAreaArrayData[self::KEY_ORIGINAL_HEIGHT];
+        $this->setOriginalHeight($originalHeight);
+
+        $originalWidth = $textAreaArrayData[self::KEY_ORIGINAL_WIDTH];
+        $this->setOriginalWidth($originalWidth);
 
         if (array_key_exists(self::KEY_REMOVED, $textAreaArrayData)) {
             $this->setRemoved($textAreaArrayData[self::KEY_REMOVED]);
@@ -136,6 +188,8 @@ class TextArea extends AbstractArea
     {
         $arrayCopy = [
             self::KEY_TYPE => self::AREA_TYPE_TEXT,
+            self::KEY_ORIGINAL_HEIGHT => $this->getOriginalHeight(),
+            self::KEY_ORIGINAL_WIDTH => $this->getOriginalWidth(),
         ];
 
         if (false === is_null($this->getRemoved())) {

--- a/src/ProjectData/Screen/Entity/Screen.php
+++ b/src/ProjectData/Screen/Entity/Screen.php
@@ -698,6 +698,9 @@ class Screen extends EntityBase
         $screenDuration = $screenArrayData[self::KEY_DURATION];
         $this->duration = $screenDuration;
 
+        $screenSelectedDuration = $screenArrayData[self::KEY_SELECTED_DURATION];
+        $this->selectedDuration = $screenSelectedDuration;
+
         $screenExtraVideoSecond = $screenArrayData[self::KEY_EXTRA_VIDEO_SECOND];
         $this->setExtraVideoSecond($screenExtraVideoSecond);
 


### PR DESCRIPTION
 - Add `editingMode` to `ProjectData`
 - Add `selectedDuration` to `Screen`
 - Add `original` Height & Width to Areas
 - Fix `currentScreenId` When Updating Project Data