### PR TITLE
Add 'Get Sound By Id' functionality to SOUNDS_API and examples

### DIFF
--- a/doc/SOUNDS_API.md
+++ b/doc/SOUNDS_API.md
@@ -3,6 +3,7 @@
 **For detailed usage please see examples for each method.**
 
 - [Get All Sounds](#get-all-sounds)
+- [Get Sound By Id](#get-sound-by-id)
 - [Get Company's Library Sounds](#get-companys-library-sounds)
 - [Get Recommended Sounds](#get-recommended-sounds)
 
@@ -27,6 +28,29 @@ $sounds = $renderforestClient->getAllSounds(15);
 - **Remember** — any given value of the duration greater than 180 will be overridden by 180!
 
 [See get all sounds example](/examples/sounds/get-all-sounds.php)
+
+### Get Sound By Id
+
+Retrieves a single library sound by its id (authorization is required).
+
+Resolves the sound directly by id, so — unlike fetching the whole list with
+`getAllSounds` and looking the sound up locally — it is not affected by the
+paginated sounds listing and works for any library sound id.
+
+```php
+<?php
+
+require '../../vendor/autoload.php';
+
+$renderforestClient = new \Renderforest\ApiClient(
+    'your-api-key',
+    'your-client-id'
+);
+
+$sound = $renderforestClient->getSoundById(1980240);
+```
+
+[See get sound by id example](/examples/sounds/get-sound-by-id.php)
 
 ### Get Company's Library Sounds
 

--- a/examples/project-data/update-project-data.php
+++ b/examples/project-data/update-project-data.php
@@ -15,8 +15,7 @@ $projectData
     ->setValue('https://sample-videos.com/video123/mp4/720/big_buck_bunny_720p_1mb.mp4');
 
 // add sound
-$allSounds = $renderforestClient->getAllSounds(100);
-$sound = $allSounds->getSoundById(1980240);
+$sound = $renderforestClient->getSoundById(1980240);
 $projectData
     ->getSounds()
     ->add($sound);

--- a/examples/sounds/get-sound-by-id.php
+++ b/examples/sounds/get-sound-by-id.php
@@ -1,0 +1,19 @@
+<?php
+
+require '../../vendor/autoload.php';
+
+$renderforestClient = new \Renderforest\ApiClient(
+    'your-api-key',
+    'your-client-id'
+);
+
+$soundId = 1980240;
+
+$sound = $renderforestClient->getSoundById($soundId);
+
+echo 'ID - ' . $sound->getId() . PHP_EOL;
+echo 'Duration - ' . $sound->getDuration() . PHP_EOL;
+echo 'Title - ' . $sound->getTitle() . PHP_EOL;
+echo 'Path - ' . $sound->getPath() . PHP_EOL;
+echo 'Low Quality Path - ' . $sound->getLowQuality() . PHP_EOL;
+echo 'Genre - ' . $sound->getGenre() . PHP_EOL;

--- a/src/ApiClient.php
+++ b/src/ApiClient.php
@@ -10,6 +10,7 @@ use Renderforest\Project\Project;
 use Renderforest\ProjectData\ProjectData;
 use Renderforest\ProjectData\Screen\Entity\Screen;
 use Renderforest\Sound\Collection\SoundCollection;
+use Renderforest\Sound\Sound;
 use Renderforest\Support\SupportTicket;
 use Renderforest\Support\SupportTicketResponse;
 use Renderforest\Template\Category\Category;
@@ -89,6 +90,9 @@ class ApiClient
 
     const SOUNDS_API_PATH_PREFIX = '/api/v1';
     const SOUNDS_API_PATH = self::SOUNDS_API_PATH_PREFIX . '/sounds';
+
+    const SOUND_BY_ID_API_PATH_PREFIX = '/api/v1';
+    const SOUND_BY_ID_API_PATH = self::SOUND_BY_ID_API_PATH_PREFIX . '/sounds/%d';
 
     const COMPANY_SOUNDS_API_PATH_PREFIX = '/api/v1';
     const COMPANY_SOUNDS_API_PATH = self::COMPANY_SOUNDS_API_PATH_PREFIX . '/sounds/library';
@@ -1031,6 +1035,50 @@ class ApiClient
         $SoundCollection->exchangeJson($json);
 
         return $SoundCollection;
+    }
+
+    /**
+     * Retrieves a single library sound by its id (authorization is required).
+     *
+     * Unlike `getAllSounds`, this resolves the sound directly by id, so it is
+     * not affected by the paginated sounds listing and works for any library
+     * sound id.
+     *
+     * @param int $soundId
+     * @return Sound
+     * @throws GuzzleException
+     */
+    public function getSoundById(int $soundId): Sound
+    {
+        $endpoint = self::SOUNDS_API_PATH;
+        $uri = self::API_ENDPOINT . sprintf(self::SOUND_BY_ID_API_PATH, $soundId);
+
+        $options = [
+            'method' => 'GET',
+            'headers' => [
+                'Accept' => 'application/json',
+                'User-Agent' => self::USER_AGENT,
+            ],
+            'endpoint' => $endpoint,
+            'uri' => $uri,
+        ];
+
+        $options = $this->setAuthorization($options);
+
+        $response = $this->httpClient->request(
+            $options['method'],
+            $options['uri'],
+            $options
+        );
+
+        $json = $response->getBody()->getContents();
+
+        $soundArrayData = json_decode($json, true)['data'];
+
+        $sound = new Sound();
+        $sound->exchangeArray($soundArrayData);
+
+        return $sound;
     }
 
     /**


### PR DESCRIPTION
- Introduced a new method `getSoundById` in the ApiClient to retrieve a single sound by its ID.
- Updated SOUNDS_API documentation to include the new endpoint.
- Modified example scripts to demonstrate usage of the new method.
- Removed unnecessary calls to fetch all sounds when retrieving a specific sound.